### PR TITLE
Cleaning up OG tags

### DIFF
--- a/arts/critics/atlarge/2013/05/15/130515crat_atlarge.html
+++ b/arts/critics/atlarge/2013/05/15/130515crat_atlarge.html
@@ -72,7 +72,7 @@ s_c_il[1].d.write=s_c_il[1].cdw;s_c_il[1].crl(0,1)
     <meta property="fb:admins" content="648235154,789168297,688620285">
     <meta property="og:image" content="http://www.newyorker.com/images/2012/09/24/g120/120924_r22590_g120_cropth.jpg">
     <meta property="og:site_name" content="The New Yorker">
-    <meta property="og:title" content="Jerry Sandusky and the Mind of a Pedophile">
+    <meta property="og:title" content="Handmade Communication">
     <meta property="og:url" content="http://www.newyorker.com/arts/critics/atlarge/2012/09/24/120924crat_atlarge_gladwell">
     <meta property="og:type" content="article">
 
@@ -80,8 +80,8 @@ s_c_il[1].d.write=s_c_il[1].cdw;s_c_il[1].crl(0,1)
     CN.config.set({
       title        : document.title,
       url          : 'http://www.newyorker.com/arts/critics/atlarge/2012/09/24/120924crat_atlarge_gladwell',
-      description  : "&#8220;Children constantly surrounded Sandusky, so much so that they became part of his persona,&#8221; Joe Posnanski writes in his new biography of Jerry Sandusky&#8217;s boss, the former Penn State head coach Joe Paterno.",
-      keywords     : "Jerry Sandusky, Child Molesters, Pedophiles, Pedophilia, &amp;#8220;Paterno&amp;#8221;, Joe Posnanski, Joe Paterno, Penn State University, Child Abuse, &amp;#8220;Identifying Child Molesters&amp;#8221;, Carla van Dam, Football Coaches, Teachers, Children, Students, E. J. Sandusky, &amp;#8220;Touched&amp;#8221;, Second Mile, Donald Silva, Jack McCallum, Bill Lyon, Philadelphia &lt;i&gt;Inquirer&lt;\/i&gt;, (Pres.) George W. Bush, Wrestling, Louis Freeh, Ronald Schreffler, Showers, Alycia Chambers, John Seasock, NBC News, Gary Schultz, Graham Spanier, Tim Curley, Jom O&amp;#8217;Hara, Mike McQueary, Envelopes, John Surma, U.S. Steel",
+      description  : "",
+      keywords     : "",
       facebook     : {pageid: "9258148868", appId: "179662042076731", apiKey: "8ecec5f3726e0601443e17e88c1558d4" },
       isiFrame     : true
     });


### PR DESCRIPTION
Stumm is upset that the link unfurls with an incorrect description on Slack. Lets fix this up.
